### PR TITLE
Upgrade gradle and convert to implementation instead of compile for dependency declaration.

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,8 @@
+TO build this locally you'll want to:
+
+$ cd react-native-image-pick/Example
+$ npm install
+$ cd ../android
+$ ./gradlew assembleDebug
+
+

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,12 +9,16 @@ def computeVersionName() {
 
 buildscript {
     repositories {
-        google()
-        jcenter()
+    maven {
+        url "https://maven.google.com"
     }
-
+    jcenter()
+    }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.0.1'
+
+        // NOTE: Do not place your application dependencies here; they belong
+        // in the individual module build.gradle files
     }
 }
 
@@ -22,8 +26,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
-
+ 
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 25
@@ -36,26 +39,32 @@ android {
 }
 
 repositories {
-    mavenCentral()
-    google()
     maven {
+        name "exampleNodeModules"
         url "$projectDir/../Example/node_modules/react-native/android"
     }
     maven {
+        name "projectLevelReactNative"
         url "$projectDir/../../react-native/android"
     }
+    mavenLocal()
+    jcenter()
+    maven {
+        url "https://maven.google.com"
+    }
+
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"  // From node_modules
+    implementation "com.facebook.react:react-native:+"  // From node_modules
 
-    testCompile "junit:junit:4.10"
-    testCompile "org.assertj:assertj-core:1.7.0"
-    testCompile "org.robolectric:robolectric:3.3.2"
+    testImplementation "junit:junit:4.10"
+    testImplementation "org.assertj:assertj-core:1.7.0"
+    testImplementation "org.robolectric:robolectric:3.3.2"
 
-    testCompile "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
-    testCompile "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"
-    testCompile "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
-    testCompile "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
-    testCompile "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
+    testImplementation "org.easytesting:fest-assert-core:${FEST_ASSERT_CORE_VERSION}"
+    testImplementation "org.powermock:powermock-api-mockito:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-module-junit4-rule:${POWERMOCK_VERSION}"
+    testImplementation "org.powermock:powermock-classloading-xstream:${POWERMOCK_VERSION}"
+    testImplementation "org.mockito:mockito-core:${MOCKITO_CORE_VERSION}"
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-image-picker",
   "description": "A React Native module that allows you to use native UI to select media from the device library or directly from the camera",
-  "version": "0.26.7-convoyv1",
+  "version": "0.26.8-convoyv1",
   "main": "index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Moves to 3.0.1 and removes the build tools version which is now provided by gradle automatically.
Migrates to the new dependency declaration formats.